### PR TITLE
feat: add daily finance reports

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -6,6 +6,7 @@ import DiagnosisView from '../views/DiagnosisView.vue';
 import RecommendationView from '../views/RecommendationView.vue';
 import BookmarkView from '../views/BookmarkView.vue';
 import NotFoundView from '../views/NotFoundView.vue';
+import FinanceReportView from '../views/FinanceReportView.vue';
 import { useAuthStore } from '../store/auth';
 
 const routes = [
@@ -35,6 +36,12 @@ const routes = [
     path: '/recommendations',
     name: 'Recommendations',
     component: RecommendationView,
+    meta: { requiresAuth: true },
+  },
+  {
+    path: '/finance',
+    name: 'Finance',
+    component: FinanceReportView,
     meta: { requiresAuth: true },
   },
   {

--- a/src/services/financeService.js
+++ b/src/services/financeService.js
@@ -1,0 +1,34 @@
+import { collection, doc, setDoc, getDocs, query, orderBy, serverTimestamp } from 'firebase/firestore';
+import { db } from './firebase';
+import { updateUserDocument } from './firestoreService.js';
+
+// Save a daily financial report for a user
+export const addDailyReport = async (uid, report) => {
+  const reportsCol = collection(db, 'users', uid, 'reports');
+  const reportRef = doc(reportsCol, report.date);
+  await setDoc(reportRef, {
+    ...report,
+    createdAt: serverTimestamp()
+  });
+
+  const reports = await getReports(uid);
+  const status = classifyBusiness(reports);
+  await updateUserDocument(uid, { umkmStatus: status });
+  return status;
+};
+
+// Retrieve all reports for a user ordered by date desc
+export const getReports = async (uid) => {
+  const reportsCol = collection(db, 'users', uid, 'reports');
+  const q = query(reportsCol, orderBy('date', 'desc'));
+  const snapshot = await getDocs(q);
+  return snapshot.docs.map((d) => ({ id: d.id, ...d.data() }));
+};
+
+// Simple classification based on total net revenue
+export const classifyBusiness = (reports) => {
+  const total = reports.reduce((sum, r) => sum + (Number(r.revenue) - Number(r.expense)), 0);
+  if (total < 50000000) return 'mikro';
+  if (total < 300000000) return 'kecil';
+  return 'menengah';
+};

--- a/src/services/recommendationService.js
+++ b/src/services/recommendationService.js
@@ -349,6 +349,10 @@ const attemptEnhancedAI = async (businessProfile, diagnosisData) => {
  */
 export const generateAIRecommendations = async (businessProfile, diagnosisData) => {
   try {
+    if (!businessProfile || !diagnosisData) {
+      console.warn('Missing business profile or diagnosis data, using rule-based recommendations');
+      return generateRuleBasedRecommendations(businessProfile || {});
+    }
     console.log('🤖 Starting AI recommendation generation process...');
     console.log('🔍 DEBUG: businessProfile:', businessProfile);
     console.log('🔍 DEBUG: diagnosisData:', diagnosisData);

--- a/src/store/finance.js
+++ b/src/store/finance.js
@@ -1,0 +1,41 @@
+import { defineStore } from 'pinia';
+import { addDailyReport, getReports } from '../services/financeService.js';
+import { useAuthStore } from './auth';
+
+export const useFinanceStore = defineStore('finance', {
+  state: () => ({
+    reports: [],
+    status: null,
+    loading: false,
+    error: null,
+  }),
+  actions: {
+    async loadReports() {
+      this.loading = true;
+      try {
+        const auth = useAuthStore();
+        this.reports = await getReports(auth.user.uid);
+        this.status = auth.user?.umkmStatus || null;
+      } catch (e) {
+        console.error(e);
+        this.error = 'Gagal memuat laporan';
+      } finally {
+        this.loading = false;
+      }
+    },
+    async addReport(report) {
+      this.loading = true;
+      try {
+        const auth = useAuthStore();
+        const status = await addDailyReport(auth.user.uid, report);
+        this.status = status;
+        this.reports = await getReports(auth.user.uid);
+      } catch (e) {
+        console.error(e);
+        this.error = 'Gagal menyimpan laporan';
+      } finally {
+        this.loading = false;
+      }
+    },
+  },
+});

--- a/src/views/DashboardView.vue
+++ b/src/views/DashboardView.vue
@@ -126,9 +126,24 @@
               >
                 🔒 Selesaikan Diagnosis Dulu
               </button>
+          </div>
+        </div>
+
+          <div class="action-card">
+            <div class="card-header">
+              <div class="card-icon">📑</div>
+            </div>
+            <div class="card-content">
+              <h3>Laporan Keuangan</h3>
+              <p>Catat pemasukan dan pengeluaran harian Anda</p>
+            </div>
+            <div class="card-actions">
+              <router-link to="/finance" class="btn btn-primary">
+                📑 Input Laporan
+              </router-link>
             </div>
           </div>
-          
+
           <div class="action-card" :class="{ 'card-disabled': !currentStage }">
             <div class="card-header">
               <div class="card-icon">🎯</div>

--- a/src/views/FinanceReportView.vue
+++ b/src/views/FinanceReportView.vue
@@ -1,0 +1,60 @@
+<template>
+  <div class="finance-report">
+    <h1>Laporan Keuangan Harian</h1>
+    <form @submit.prevent="save">
+      <div>
+        <label>Tanggal</label>
+        <input type="date" v-model="form.date" />
+      </div>
+      <div>
+        <label>Pendapatan</label>
+        <input type="number" v-model.number="form.revenue" />
+      </div>
+      <div>
+        <label>Pengeluaran</label>
+        <input type="number" v-model.number="form.expense" />
+      </div>
+      <button type="submit" :disabled="finance.loading">Simpan</button>
+    </form>
+
+    <div v-if="finance.status" class="status">
+      Status UMKM: {{ finance.status }}
+    </div>
+
+    <ul>
+      <li v-for="r in finance.reports" :key="r.id">
+        {{ r.date }} - Pendapatan: {{ r.revenue }} | Pengeluaran: {{ r.expense }}
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script setup>
+import { reactive, onMounted } from 'vue';
+import { useFinanceStore } from '../store/finance.js';
+
+const finance = useFinanceStore();
+const form = reactive({
+  date: new Date().toISOString().substring(0,10),
+  revenue: 0,
+  expense: 0,
+});
+
+onMounted(() => {
+  finance.loadReports();
+});
+
+const save = () => {
+  finance.addReport({ ...form });
+};
+</script>
+
+<style scoped>
+.finance-report {
+  max-width: 400px;
+  margin: 0 auto;
+}
+.finance-report form div {
+  margin-bottom: 1rem;
+}
+</style>


### PR DESCRIPTION
## Summary
- add finance service, store and view for daily financial reporting
- link finance report view in dashboard and router
- fallback to rule-based recommendations when profile or diagnosis data missing

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Invalid option '--ignore-path')*


------
https://chatgpt.com/codex/tasks/task_e_689a8a321e708325ab5196f21b993490